### PR TITLE
Python 3 support

### DIFF
--- a/mailer.py
+++ b/mailer.py
@@ -28,6 +28,7 @@ Sample code:
     sender.send(message)
 
 """
+from __future__ import print_function
 import smtplib
 import threading
 import Queue
@@ -92,7 +93,7 @@ class Mailer(object):
         them as a list:
         mailer.send([msg1, msg2, msg3])
         """
-        print self.host, self.port
+        print(self.host, self.port)
         server = smtplib.SMTP(self.host, self.port)
 
         if self._usr and self._pwd:
@@ -138,7 +139,7 @@ class Mailer(object):
                 bcc = list(msg.BCC)
 
         you = to + cc + bcc
-        print me, you, msg.as_string()
+        print(me, you, msg.as_string())
         server.sendmail(me, you, msg.as_string())
 
 class Message(object):

--- a/mailer.py
+++ b/mailer.py
@@ -31,8 +31,12 @@ Sample code:
 from __future__ import print_function
 import smtplib
 import threading
-import Queue
 import uuid
+
+try:
+    import Queue
+except ImportError:
+    import queue as Queue  # Renamed in Python3
 
 # this is to support name changes
 # from version 2.4 to version 2.5

--- a/mailer.py
+++ b/mailer.py
@@ -38,6 +38,11 @@ try:
 except ImportError:
     import queue as Queue  # Renamed in Python3
 
+try:
+    basestring = basestring
+except NameError:
+    basestring = (str, bytes)  # Python3 support
+
 # this is to support name changes
 # from version 2.4 to version 2.5
 try:

--- a/main.py
+++ b/main.py
@@ -2,11 +2,12 @@
 # from email.mime.multipart import MIMEMultipart
 # from email.mime.text import MIMEText
 # import smtplib
+from __future__ import print_function
 import mailer
 import sys
 
 if len(sys.argv) < 8 :
-  print 'There should be 8 arguments'
+  print('There should be 8 arguments')
   sys.exit(1)
 
 fromaddr = str(sys.argv[1])

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: email-notify
-version: 1.0.1
+version: 1.0.2
 description: Send an email message
 keywords:
   - notification


### PR DESCRIPTION
Currently using Python3 in wercker app causes an error with this step:

```
cd $WERCKER_SOURCE_DIR
(venv)$ export WERCKER_STEP_ROOT="/wercker/steps/wercker/email-notify/1.0.1"
(venv)$ export WERCKER_STEP_ID=""
(venv)$ export WERCKER_STEP_NAME="email-notify"
(venv)$ export WERCKER_REPORT_NUMBERS_FILE="$WERCKER_REPORT_DIR/$WERCKER_STEP_ID/numbers.ini"
(venv)$ export WERCKER_REPORT_MESSAGE_FILE="$WERCKER_REPORT_DIR/$WERCKER_STEP_ID/message.txt"
(venv)$ export WERCKER_REPORT_ARTIFACTS_DIR="$WERCKER_REPORT_DIR/$WERCKER_STEP_ID/artifacts"
(venv)$ mkdir -p $WERCKER_REPORT_ARTIFACTS_DIR
(venv)$ export WERCKER_STEP_TEMP="/tmp/$WERCKER_STEP_ID"
(venv)$ source '/wercker/wercker-build-essentials/init.sh'
(venv)$ mkdir -p $WERCKER_STEP_TEMP
(venv)$ export WERCKER_EMAIL_NOTIFY_FROM="#### "
(venv)$ export WERCKER_EMAIL_NOTIFY_TO="####"
(venv)$ export WERCKER_EMAIL_NOTIFY_USERNAME="####"
(venv)$ export WERCKER_EMAIL_NOTIFY_PASSWORD="$EMAIL_PASSWORD"
(venv)$ export WERCKER_EMAIL_NOTIFY_HOST="####"
(venv)$ export WERCKER_EMAIL_NOTIFY_ON="always"
(venv)$ source "$WERCKER_STEP_ROOT/run.sh"
File "/wercker/steps/wercker/email-notify/1.0.1/main.py", line 9
print 'There should be 8 arguments'
^
SyntaxError: invalid syntax
```